### PR TITLE
update AboutLibraries to v14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Kotlin
+*.kotlin_module
+.kotlin/
+
+#JVM
+*.hprof
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'com.mikepenz.aboutlibraries.plugin.android'
 
 android {
     compileSdk = 37
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
@@ -54,11 +61,20 @@ android {
     namespace = 'fr.gaulupeau.apps.InThePoche'
     buildFeatures {
         buildConfig = true
+        compose true
     }
 }
 
 dependencies {
+    // Compose
+    def composeBom = platform("androidx.compose:compose-bom:2026.04.01")
+    implementation composeBom
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.activity:activity-compose:1.13.0"
+
     implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.core:core-ktx:1.18.0'
     implementation 'androidx.media:media:1.7.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
@@ -72,7 +88,8 @@ dependencies {
     implementation 'org.conscrypt:conscrypt-android:2.5.3'
     implementation 'com.facebook.stetho:stetho:1.6.0'
     implementation 'com.facebook.stetho:stetho-okhttp3:1.6.0'
-    implementation 'com.mikepenz:aboutlibraries:7.1.0'
+    implementation "com.mikepenz:aboutlibraries-core:14.0.1"
+    implementation "com.mikepenz:aboutlibraries-compose-m3:14.0.1"
     implementation 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:v2.0.0-beta.6'
     implementation 'org.slf4j:slf4j-android:1.7.36'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,6 +131,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name="fr.gaulupeau.apps.Poche.ui.AboutActivity" />
+
         <receiver
             android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true">

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AboutActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AboutActivity.java
@@ -1,0 +1,19 @@
+package fr.gaulupeau.apps.Poche.ui;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.compose.ui.platform.ComposeView;
+import android.os.Bundle;
+
+import fr.gaulupeau.apps.InThePoche.R;
+
+public class AboutActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_about);
+
+        ComposeView composeView = findViewById(R.id.compose_view);
+        AboutLibsHelperKt.showAboutLibraries(composeView);  // Kotlin Extension = statische Methode in Java
+    }
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AboutLibsHelper.kt
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AboutLibsHelper.kt
@@ -1,0 +1,10 @@
+package fr.gaulupeau.apps.Poche.ui
+
+import androidx.compose.ui.platform.ComposeView
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+
+fun ComposeView.showAboutLibraries() {
+    setContent {
+        LibrariesContainer()
+    }
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -40,8 +40,6 @@ import androidx.fragment.app.Fragment;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.navigation.NavigationView;
-import com.mikepenz.aboutlibraries.Libs;
-import com.mikepenz.aboutlibraries.LibsBuilder;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -499,27 +497,11 @@ public class MainActivity extends AppCompatActivity
                 break;
 
             case R.id.nav_about:
-                Libs.ActivityStyle style;
-                switch (Themes.getCurrentTheme()) {
-                    case DARK:
-                    case DARK_CONTRAST:
-                        style = Libs.ActivityStyle.DARK;
-                        break;
-
-                    default:
-                        style = Libs.ActivityStyle.LIGHT_DARK_TOOLBAR;
-                        break;
-                }
                 CharSequence aboutCharSequence = getText(R.string.aboutText);
                 String aboutString = aboutCharSequence instanceof Spanned
                         ? Html.toHtml((Spanned) aboutCharSequence)
                         : aboutCharSequence.toString();
-                new LibsBuilder()
-                        .withActivityStyle(style)
-                        .withAboutIconShown(true)
-                        .withAboutVersionShown(true)
-                        .withAboutDescription(aboutString)
-                        .start(this);
+                startActivity(new Intent(this, AboutActivity.class));
                 break;
         }
 

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        kotlin_version = '2.3.21'
+    }
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
+        classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:14.0.1"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
-android.builtInKotlin=false
 android.defaults.buildfeatures.resvalues=true
 android.dependency.useConstraints=true
 android.enableAppCompileTimeRClass=false
 android.enableJetifier=true
-android.newDsl=false
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.r8.optimizedResourceShrinking=false
@@ -12,3 +10,4 @@ android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.uniquePackageNames=false
 android.useAndroidX=true
 android.usesSdkInManifest.disallowed=false
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
This PR is dependent on #1493

Successfully updated to v14 of aboutlibraries and got kotlin/compose as dependency.

Style needs to be applied and logo/version of our app needs to be added (https://github.com/mikepenz/AboutLibraries#advanced-usage). Currently it looks like this:

<img width="320" alt="Screenshot wallabag" src="https://github.com/user-attachments/assets/7f5d4813-8181-47ac-8b1a-8da078c8dabd" />


